### PR TITLE
Add ability to strip formatting

### DIFF
--- a/slackminion/dispatcher.py
+++ b/slackminion/dispatcher.py
@@ -3,7 +3,7 @@ from flask import current_app, request
 from slackminion.exceptions import DuplicateCommandError
 from slackminion.slack.conversation import SlackConversation
 import unicodedata
-from slackminion.utils.util import format_docstring
+from slackminion.utils.util import format_docstring, strip_formatting
 import logging
 import inspect
 import re
@@ -98,8 +98,12 @@ class MessageDispatcher(object):
                     return '_ignored_', "", None
 
                 # Strip formatting if requested by plugin
-                if f.cmd_options.get('strip_formatting', None):
-                    msg_args = self._strip_formatting(msg_args)
+                if f.cmd_options.get('strip_formatting'):
+                    input_string = ' '.join(msg_args)
+                    self.log.debug('Calling strip_format with %s', input_string)
+                    input_string = strip_formatting(input_string)
+                    self.log.debug('Format Stripped message is %s', input_string)
+                    msg_args = input_string.split(' ')
                 try:
                     if f.is_async:
                         if not dev_mode:
@@ -211,45 +215,3 @@ class MessageDispatcher(object):
             channel_ignored = not cmd.while_ignored
         return channel_ignored
 
-    def _strip_formatting(self, args):
-        """ Remove any slack specific formatting from messages.
-        See https://api.slack.com/reference/surfaces/formatting#retrieving-messages
-        Code heavily borrowed from  hubot's removeFormatting method
-        https://github.com/slackapi/hubot-slack/blob/d9c8d1c34afc2ff5253fa0abbff0ec446dffcb39/src/slack.coffee#L137
-        """
-        arg_string = " ".join(args)
-        self.log.info("_strip_formatting called with: %s", arg_string)
-
-        special_pattern = re.compile(r"""
-            <              # opening angle bracket
-            ([\@\#\!])     # link type for channel, username or command
-            (\w+)          # id
-            (?:\|([^>]+))? # |label (optional)
-            >              # closing angle bracket
-            """, re.VERBOSE)
-
-        link_pattern = re.compile(r"""
-            <              # opening angle bracket
-            ([^>\|]+)      # link
-            (?:\|([^>]+))? # label
-            >              # closing angle bracket
-            """, re.VERBOSE)
-
-        def _special_match_substitute(match):
-            """ If we find the label, remove the id """
-            if match.group(3):
-                return "{}{}".format(match.group(1), match.group(3))
-            else:
-                return "{}{}".format(match.group(1), match.group(2))
-
-        def _link_match_substitute(match):
-            """ If we find the label, use it. If not, use the original link"""
-            if match.group(2):
-                return match.group(2)
-            else:
-                return match.group(1)
-
-        arg_string = re.sub(special_pattern, _special_match_substitute, arg_string)
-        arg_string = re.sub(link_pattern, _link_match_substitute, arg_string)
-        self.log.info("_strip_formatting formatted response: %s", arg_string)
-        return arg_string.split(" ")

--- a/slackminion/plugin/__init__.py
+++ b/slackminion/plugin/__init__.py
@@ -3,7 +3,7 @@ from .manager import PluginManager  # noqa
 
 
 def cmd(admin_only=False, acl='*', aliases=None, while_ignored=False,
-        reply_in_thread=False, reply_broadcast=False, parse=None, *args, **kwargs):
+        reply_in_thread=False, reply_broadcast=False, parse=None, strip_formatting=False, *args, **kwargs):
     """
     Decorator to mark plugin functions as commands in the form of !<cmd_name>
 
@@ -14,6 +14,7 @@ def cmd(admin_only=False, acl='*', aliases=None, while_ignored=False,
     * reply_in_thread - determines whether bot replies in the channel or a thread
     * reply_broadcast - if replying in a thread, whether to also send the message to the channel
     * parse - Set to "full" for the slack api to linkify names and channels
+    * strip_formatting - Remove formtting added by slack  to the messages
     """
 
     def wrapper(func):
@@ -28,6 +29,7 @@ def cmd(admin_only=False, acl='*', aliases=None, while_ignored=False,
             'reply_in_thread': reply_in_thread,
             'reply_broadcast': reply_broadcast,
             'parse': parse,
+            'strip_formatting': strip_formatting
         }
         return func
 

--- a/slackminion/plugin/__init__.py
+++ b/slackminion/plugin/__init__.py
@@ -14,7 +14,7 @@ def cmd(admin_only=False, acl='*', aliases=None, while_ignored=False,
     * reply_in_thread - determines whether bot replies in the channel or a thread
     * reply_broadcast - if replying in a thread, whether to also send the message to the channel
     * parse - Set to "full" for the slack api to linkify names and channels
-    * strip_formatting - Remove formtting added by slack  to the messages
+    * strip_formatting - Remove formtting added by slack to the messages
     """
 
     def wrapper(func):
@@ -29,7 +29,7 @@ def cmd(admin_only=False, acl='*', aliases=None, while_ignored=False,
             'reply_in_thread': reply_in_thread,
             'reply_broadcast': reply_broadcast,
             'parse': parse,
-            'strip_formatting': strip_formatting
+            'strip_formatting': strip_formatting,
         }
         return func
 

--- a/slackminion/tests/fixtures/objects.py
+++ b/slackminion/tests/fixtures/objects.py
@@ -41,3 +41,7 @@ class DummyPlugin(BasePlugin):
     @cmd(parse=True)
     async def asyncparse(self, msg, args):
         return 'async parse command #parse'
+
+    @cmd(strip_formatting=True)
+    async def stripformat(self, msg, args):
+        return 'Format Stripped, Success %s' % args

--- a/slackminion/tests/fixtures/objects.py
+++ b/slackminion/tests/fixtures/objects.py
@@ -1,5 +1,6 @@
 from .variables import *
 from slackminion.plugin import BasePlugin, cmd
+from slackminion.utils.util import strip_formatting
 
 
 class TestChannel(object):
@@ -44,4 +45,4 @@ class DummyPlugin(BasePlugin):
 
     @cmd(strip_formatting=True)
     async def stripformat(self, msg, args):
-        return 'Format Stripped, Success %s' % args
+        return strip_formatting(' '.join(args))

--- a/slackminion/tests/test_dispatcher.py
+++ b/slackminion/tests/test_dispatcher.py
@@ -49,17 +49,15 @@ class TestDispatcher(unittest.TestCase):
 
     @async_test
     async def test_strip_formatting(self):
-        test_string = '!stripformat <@U123456> check <#C123456|test-channel> has <https://www.pinterest.com|www.pinterest.com>'
-        expected_response = '@U123456 check #test-channel has www.pinterest.com'.split(" ")
-        self.dispatcher.register_plugin(self.p)
-        e = SlackEvent(event_type='message', **{'data': {'text': test_string}})
+        test_string = "!stripformat <@U123456> check <#C123456|test-channel> has <https://www.pinterest.com|www.pinterest.com>"
+        expected_response = "@U123456 check #test-channel has www.pinterest.com"
+        e = SlackEvent(event_type="message", **{"data": {"text": test_string}})
         e.user = mock.Mock()
         e.channel = test_conversation
-        parsed_message = self.dispatcher._parse_message(e)
-        self.assertListEqual(self.dispatcher._strip_formatting(parsed_message[1:]), expected_response)
-        self.dispatcher._strip_formatting = mock.MagicMock(side_effect=self.dispatcher._strip_formatting)
-        cmd, output, cmd_opts =  await self.dispatcher.push(e)
-        self.dispatcher._strip_formatting.assert_called_with(parsed_message[1:])
+        self.dispatcher.register_plugin(self.p)
+        cmd, output, cmd_opts = await self.dispatcher.push(e)
+        assert cmd_opts.get("strip_formatting") is True
+        self.assertEqual(expected_response, output)
 
     def test_unignore_nonignored_channel(self):
         c = SlackConversation(conversation=test_channel, api_client=test_payload.get('api_client'))

--- a/slackminion/tests/test_dispatcher.py
+++ b/slackminion/tests/test_dispatcher.py
@@ -47,6 +47,20 @@ class TestDispatcher(unittest.TestCase):
         e = SlackEvent(event_type='message', **{'data': {'text': 'Hello\xa0world'}})
         assert self.dispatcher._parse_message(e) == ['Hello', 'world']
 
+    @async_test
+    async def test_strip_formatting(self):
+        test_string = '!stripformat <@U123456> check <#C123456|test-channel> has <https://www.pinterest.com|www.pinterest.com>'
+        expected_response = '@U123456 check #test-channel has www.pinterest.com'.split(" ")
+        self.dispatcher.register_plugin(self.p)
+        e = SlackEvent(event_type='message', **{'data': {'text': test_string}})
+        e.user = mock.Mock()
+        e.channel = test_conversation
+        parsed_message = self.dispatcher._parse_message(e)
+        self.assertListEqual(self.dispatcher._strip_formatting(parsed_message[1:]), expected_response)
+        self.dispatcher._strip_formatting = mock.MagicMock(side_effect=self.dispatcher._strip_formatting)
+        cmd, output, cmd_opts =  await self.dispatcher.push(e)
+        self.dispatcher._strip_formatting.assert_called_with(parsed_message[1:])
+
     def test_unignore_nonignored_channel(self):
         c = SlackConversation(conversation=test_channel, api_client=test_payload.get('api_client'))
         self.assertFalse(self.dispatcher.unignore(c))

--- a/slackminion/tests/test_util.py
+++ b/slackminion/tests/test_util.py
@@ -1,0 +1,14 @@
+import unittest
+from slackminion.utils.util import strip_formatting
+
+
+class TestCase(unittest.TestCase):
+
+    def test_strip_formatting(self):
+        test_string = '<@U123456> check <#C123456|test-channel> has <https://www.pinterest.com|www.pinterest.com>'
+        expected_response = '@U123456 check #test-channel has www.pinterest.com'
+        self.assertEqual(expected_response, strip_formatting(test_string))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Plugins need the ability to strip formatting added by Slack. Rather than do this in a plugin, provide an option in dispatcher to strip formatting before sending messages to the plugin.