### PR TITLE
Rename blacklist to denylist

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
             'slackclient==2.5.0',
             'websocket-client >=0.35, <0.55.0',
             'Werkzeug>=0.10.4',
+            'chardet<4.0',
         ],
         setup_requires=[
             'pytest-runner'

--- a/slackminion/plugin/manager.py
+++ b/slackminion/plugin/manager.py
@@ -85,19 +85,19 @@ class PluginManager(object):
         state = {}
         savable_plugins = [x for x in self.plugins if x._dont_save is False]
         for p in savable_plugins:
-            attr_blacklist = [
+            attr_denylist = [
                 '_bot',
                 '_commit',
                 '_dont_save',
                 '_state_handler',
                 '_timer_callbacks',
                 '_version',
-                'attr_blacklist',
+                'attr_denylist',
                 'config',
                 'log',
             ]
-            attr_blacklist.extend(getattr(p, 'attr_blacklist', []))
-            attrs = {k: v for k, v in list(p.__dict__.items()) if k not in attr_blacklist}
+            attr_denylist.extend(getattr(p, 'attr_denylist', []))
+            attrs = {k: v for k, v in list(p.__dict__.items()) if k not in attr_denylist}
             state[type(p).__name__] = attrs
             self.log.debug("Plugin %s: %s", type(p).__name__, attrs)
         state = json.dumps(state)

--- a/slackminion/plugins/core/__init__.py
+++ b/slackminion/plugins/core/__init__.py
@@ -1,1 +1,1 @@
-version = '1.0.4'
+version = '1.1.0'


### PR DESCRIPTION
Rename blacklist to denylist. If this change is pulled in, plugins needs
to be changed to use the new attribute (blacklist to denylist) to avoid
secrets being exposed. Hence I updated the minor release version.