### PR TITLE
Slack sdk

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
             'PyYAML>=4.2b',
             'requests >=2.11, <3.0a0',
             'six >=1.10, <2.0a0',
-            'slackclient==2.5.0',
+            'slack_sdk==3.13.0',
             'websocket-client >=0.35, <0.55.0',
             'Werkzeug>=0.10.4',
             'aiohttp==3.7.4.post0',

--- a/slackminion/bot.py
+++ b/slackminion/bot.py
@@ -8,7 +8,7 @@ from slackminion.plugins.core import version as my_version
 from slackminion.slack.rtm_client import MyRTMClient
 import logging
 import datetime
-import slack
+from slack_sdk.web.async_client import AsyncWebClient
 import asyncio
 
 ignore_subtypes = [
@@ -116,7 +116,7 @@ class Bot(object):
         self.plugin_manager.load_state()
 
         self.rtm_client = MyRTMClient(token=self.config.get('slack_token'), run_async=True)
-        self.api_client = slack.WebClient(token=self.config.get('slack_token'), run_async=True)
+        self.api_client = AsyncWebClient(token=self.config.get('slack_token'))
 
         self.always_send_dm = ['_unauthorized_']
         if 'always_send_dm' in self.config:

--- a/slackminion/plugins/core/__init__.py
+++ b/slackminion/plugins/core/__init__.py
@@ -1,1 +1,1 @@
-version = '1.1.9'
+version = '1.2.0'

--- a/slackminion/slack/rtm_client.py
+++ b/slackminion/slack/rtm_client.py
@@ -1,4 +1,4 @@
-from slack import RTMClient
+from slack_sdk.rtm import RTMClient
 
 
 class MyRTMClient(RTMClient):

--- a/slackminion/tests/test_bot.py
+++ b/slackminion/tests/test_bot.py
@@ -32,7 +32,7 @@ class TestBot(unittest.TestCase):
         assert self.object.commit == 'HEAD'
 
     @mock.patch('slackminion.bot.AsyncTaskManager')
-    @mock.patch('slackminion.bot.slack')
+    @mock.patch('slackminion.bot.AsyncWebClient')
     def test_start(self, mock_slack, mock_async):
         self.object.start()
         assert self.object.is_setup is True

--- a/slackminion/utils/async_task.py
+++ b/slackminion/utils/async_task.py
@@ -91,7 +91,7 @@ class AsyncTaskManager(object):
     def add_signal_handlers(self):
         signals = [signal.SIGINT, signal.SIGTERM, signal.SIGHUP]
         # these need to be added every time RTMClient starts/restarts, as
-        # slackclient adds its own signal handler which overrides these
+        # slack_sdk adds its own signal handler which overrides these
         for sig in signals:
             if self.event_loop._signal_handlers[sig]._callback != self.graceful_shutdown:
                 self.log.debug(f'Adding signal handler for {sig}')


### PR DESCRIPTION
move to slack_sdk 

According to https://slack.dev/python-slack-sdk/v3-migration/

> the slackclient project is in maintenance mode now and this slack_sdk project is the successor.

closes #52 