### PR TITLE
Stop using setup.py test and install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,4 +23,5 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Tests
       run: |
-        python setup.py test
+        pip install tox
+        tox

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,8 @@ jobs:
         python-version: 3.7
     - name: Tests
       run: |
-        python setup.py test
+        pip install tox
+        tox
     - name: Build pip
       run: |
         python setup.py sdist

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A python bot framework for slack
 It is recommended that you set up a virtual environment in which to run slackminion. Install the app:
 
 ```
-$ python setup.py install
+$ pip install
 ```
 
 Run the application using the built-in `slackminion` command. Use a config.yaml to customize the plugins you wish to run. You can test your plugin configuration before running a live app:
@@ -29,12 +29,11 @@ http://slackminion.readthedocs.org/
 It is recommended that you set up a virtual environment in which to run slackminion. Bootstrapping the application should be pretty straightforward:
 
 ```
-$ python setup.py develop
-$ python setup.py test
+tox
 ```
 
 All tests should pass before and after you make your commits.
 
 ## Python3 Support
 
-As of Version 0.10, slackminion requires Python >= 3.6.  This is due to both the upgrade of the slack client (which requries Python3), and the usage of async functions and f-strings within the slackminion code.  If you need Python 2.x, please pin version >= 0.9.x of slackminion.
+As of Version 0.10, slackminion requires Python >= 3.6.  This is due to both the upgrade of the slack client (which requires Python3), and the usage of async functions and f-strings within the slackminion code.  If you need Python 2.x, please pin version >= 0.9.x of slackminion.

--- a/setup.py
+++ b/setup.py
@@ -25,18 +25,6 @@ setup(
             'Werkzeug>=0.10.4',
             'aiohttp==3.7.4.post0',
         ],
-        setup_requires=[
-            'pytest-runner'
-        ],
-        tests_require=[
-            'pytest>=5.4.0',
-            'pytest-asyncio',
-            'pytest-cov==2.6.1',
-            'codeclimate-test-reporter==0.1.2',
-            'coverage==4.5.2',
-            'mock==3.0.5',
-            'future',
-        ],
         entry_points={
             'console_scripts': [
                 'slackminion = slackminion.__main__:main',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,8 @@
+pytest>=5.4.0
+pytest-asyncio
+pytest-cov==2.6.1
+codeclimate-test-reporter==0.1.2
+coverage==4.5.2
+mock==3.0.5
+future
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+skipsdist=False
+
+[testenv]
+deps = -r{toxinidir}/test-requirements.txt
+commands =  pytest {posargs}


### PR DESCRIPTION
Both are deprecated:
* https://setuptools.pypa.io/en/latest/history.html#id100
* https://setuptools.pypa.io/en/latest/history.html#id430

Instead use tox, and pip install as recommended here
https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html#summary