### PR TITLE
Add isort for import ordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  build:
+  'tests':
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -25,3 +25,7 @@ jobs:
       run: |
         pip install tox
         tox
+    - name: Lint
+      run: |
+        pip install tox
+        tox -eisort

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,8 +12,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
+
 from slackminion.plugins.core import version
 
 setup(

--- a/slackminion/__init__.py
+++ b/slackminion/__init__.py
@@ -1,2 +1,3 @@
 from pkgutil import extend_path  # pragma: nocover
+
 __path__ = extend_path(__path__, __name__)  # pragma: nocover

--- a/slackminion/__main__.py
+++ b/slackminion/__main__.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 import signal
 import sys
+
 import yaml
 
 from slackminion.bot import Bot

--- a/slackminion/bot.py
+++ b/slackminion/bot.py
@@ -1,15 +1,17 @@
+import asyncio
+import datetime
+import logging
+
+from slack_sdk.web.async_client import AsyncWebClient
+
 from slackminion.dispatcher import MessageDispatcher
-from slackminion.slack import SlackEvent, SlackUser, SlackConversation
 from slackminion.exceptions import NotSetupError
 from slackminion.plugin import PluginManager
-from slackminion.webserver import Webserver
-from slackminion.utils.async_task import AsyncTaskManager
 from slackminion.plugins.core import version as my_version
+from slackminion.slack import SlackConversation, SlackEvent, SlackUser
 from slackminion.slack.rtm_client import MyRTMClient
-import logging
-import datetime
-from slack_sdk.web.async_client import AsyncWebClient
-import asyncio
+from slackminion.utils.async_task import AsyncTaskManager
+from slackminion.webserver import Webserver
 
 ignore_subtypes = [
     'bot_message',

--- a/slackminion/dispatcher.py
+++ b/slackminion/dispatcher.py
@@ -1,10 +1,12 @@
-from six import string_types
-from flask import current_app, request
-from slackminion.exceptions import DuplicateCommandError
-import unicodedata
-from slackminion.utils.util import format_docstring, strip_formatting
-import logging
 import inspect
+import logging
+import unicodedata
+
+from flask import current_app, request
+from six import string_types
+
+from slackminion.exceptions import DuplicateCommandError
+from slackminion.utils.util import format_docstring, strip_formatting
 
 
 class BaseCommand(object):

--- a/slackminion/plugin/base.py
+++ b/slackminion/plugin/base.py
@@ -1,5 +1,6 @@
-from six import string_types
 import logging
+
+from six import string_types
 
 from slackminion.slack import SlackConversation, SlackUser
 

--- a/slackminion/plugin/manager.py
+++ b/slackminion/plugin/manager.py
@@ -1,6 +1,6 @@
+import inspect
 import json
 import logging
-import inspect
 from datetime import datetime
 
 

--- a/slackminion/plugins/__init__.py
+++ b/slackminion/plugins/__init__.py
@@ -1,2 +1,3 @@
 from pkgutil import extend_path
+
 __path__ = extend_path(__path__, __name__)

--- a/slackminion/plugins/core/core.py
+++ b/slackminion/plugins/core/core.py
@@ -1,6 +1,7 @@
 from datetime import datetime
-from flask import render_template
 from operator import itemgetter
+
+from flask import render_template
 
 from slackminion.plugin import cmd, webhook
 from slackminion.plugin.base import BasePlugin

--- a/slackminion/plugins/state/__init__.py
+++ b/slackminion/plugins/state/__init__.py
@@ -1,4 +1,5 @@
 from pkgutil import extend_path
+
 from slackminion.plugin.base import BasePlugin
 
 __path__ = extend_path(__path__, __name__)

--- a/slackminion/plugins/test.py
+++ b/slackminion/plugins/test.py
@@ -1,4 +1,5 @@
 from ..plugin import cmd, webhook
+
 try:
     from slackminion.plugins.core import commit
 except ImportError:

--- a/slackminion/slack/__init__.py
+++ b/slackminion/slack/__init__.py
@@ -1,3 +1,3 @@
+from .conversation import *
 from .event import SlackEvent
 from .user import SlackUser
-from .conversation import *

--- a/slackminion/tests/fixtures/__init__.py
+++ b/slackminion/tests/fixtures/__init__.py
@@ -1,6 +1,6 @@
 import unittest
 from unittest import mock
-from .variables import *
-from .objects import *
-from .decorators import *
 
+from .decorators import *
+from .objects import *
+from .variables import *

--- a/slackminion/tests/fixtures/objects.py
+++ b/slackminion/tests/fixtures/objects.py
@@ -1,6 +1,7 @@
-from .variables import *
 from slackminion.plugin import BasePlugin, cmd
 from slackminion.utils.util import strip_formatting
+
+from .variables import *
 
 
 class TestChannel(object):

--- a/slackminion/tests/fixtures/variables.py
+++ b/slackminion/tests/fixtures/variables.py
@@ -1,6 +1,7 @@
-from unittest import mock
-from slackminion.slack import SlackConversation, SlackUser, SlackEvent
 import asyncio
+from unittest import mock
+
+from slackminion.slack import SlackConversation, SlackEvent, SlackUser
 
 
 def AsyncMock():

--- a/slackminion/tests/test_bot.py
+++ b/slackminion/tests/test_bot.py
@@ -1,9 +1,11 @@
+from copy import deepcopy
+
 import yaml
+
 from slackminion.bot import Bot
 from slackminion.exceptions import NotSetupError
 from slackminion.plugins.core import version
 from slackminion.tests.fixtures import *
-from copy import deepcopy
 
 
 class PluginWithEvents(BasePlugin):

--- a/slackminion/tests/test_core/test_acl.py
+++ b/slackminion/tests/test_core/test_acl.py
@@ -1,5 +1,5 @@
-from slackminion.plugins.core.acl import AuthManager
 from slackminion.dispatcher import MessageDispatcher
+from slackminion.plugins.core.acl import AuthManager
 from slackminion.tests.fixtures import *
 
 

--- a/slackminion/tests/test_core/test_core.py
+++ b/slackminion/tests/test_core/test_core.py
@@ -1,7 +1,7 @@
+from slackminion.dispatcher import MessageDispatcher
 from slackminion.plugins.core.core import Core
 from slackminion.tests.fixtures import *
 from slackminion.utils.util import format_docstring
-from slackminion.dispatcher import MessageDispatcher
 from slackminion.webserver import Webserver
 
 # command, help

--- a/slackminion/tests/test_dispatcher.py
+++ b/slackminion/tests/test_dispatcher.py
@@ -1,7 +1,8 @@
+from copy import deepcopy
+
+from slackminion.dispatcher import MessageDispatcher
 from slackminion.exceptions import DuplicateCommandError
 from slackminion.tests.fixtures import *
-from slackminion.dispatcher import MessageDispatcher
-from copy import deepcopy
 
 test_data_mapping = []
 

--- a/slackminion/tests/test_plugin/test_base.py
+++ b/slackminion/tests/test_plugin/test_base.py
@@ -1,6 +1,5 @@
-from slackminion.plugin import BasePlugin
 import slackminion.plugin.base
-
+from slackminion.plugin import BasePlugin
 from slackminion.tests.fixtures import *
 
 

--- a/slackminion/tests/test_plugin/test_manager.py
+++ b/slackminion/tests/test_plugin/test_manager.py
@@ -1,5 +1,5 @@
-from slackminion.tests.fixtures import *
 from slackminion.plugin import PluginManager
+from slackminion.tests.fixtures import *
 
 
 class PluginWithEvents(BasePlugin):

--- a/slackminion/tests/test_slack/test_conversation.py
+++ b/slackminion/tests/test_slack/test_conversation.py
@@ -1,5 +1,5 @@
-from slackminion.tests.fixtures import *
 from slackminion.slack.conversation import SlackConversation
+from slackminion.tests.fixtures import *
 
 TEST_CONVERSATION = {
     'id': 'C02KT31H9GX',

--- a/slackminion/tests/test_slack/test_event.py
+++ b/slackminion/tests/test_slack/test_event.py
@@ -1,4 +1,5 @@
 from unittest import mock
+
 from slackminion.slack.conversation import SlackConversation
 from slackminion.tests.fixtures import *
 

--- a/slackminion/tests/test_slack/test_user.py
+++ b/slackminion/tests/test_slack/test_user.py
@@ -1,6 +1,7 @@
-from slackminion.tests.fixtures import *
 import unittest
 from unittest import mock
+
+from slackminion.tests.fixtures import *
 
 
 class TestSlackUser(unittest.TestCase):

--- a/slackminion/tests/test_util.py
+++ b/slackminion/tests/test_util.py
@@ -1,4 +1,5 @@
 import unittest
+
 from slackminion.utils.util import strip_formatting
 
 

--- a/slackminion/utils/async_task.py
+++ b/slackminion/utils/async_task.py
@@ -1,10 +1,10 @@
-from contextlib import suppress
 import asyncio
-import logging
-import time
 import functools
 import inspect
+import logging
 import signal
+import time
+from contextlib import suppress
 
 
 class CallLater:

--- a/slackminion/utils/util.py
+++ b/slackminion/utils/util.py
@@ -1,9 +1,10 @@
-from slackminion.slack import SlackUser, SlackConversation
-import textwrap
 import asyncio
-import os
 import getpass
+import os
 import re
+import textwrap
+
+from slackminion.slack import SlackConversation, SlackUser
 
 
 def format_docstring(docstring):

--- a/slackminion/webserver.py
+++ b/slackminion/webserver.py
@@ -1,10 +1,10 @@
 import logging
 import os
-import requests
-
-from flask import Flask, request
 from threading import Thread
 from uuid import uuid4 as uuid
+
+import requests
+from flask import Flask, request
 
 
 class Webserver(object):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,5 +4,6 @@ pytest-cov==2.6.1
 codeclimate-test-reporter==0.1.2
 coverage==4.5.2
 mock==3.0.5
+isort==5.10.0
 future
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,15 @@
 [tox]
+envlist = py3, isort
 skipsdist=False
 
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt
 commands =  pytest {posargs}
+
+
+[testenv:isort]
+commands =  isort --check .
+
+
+[isort]
+profile = black


### PR DESCRIPTION
Instead of requiring developers to group imports by hand use isort
https://github.com/PyCQA/isort