### PR TITLE
Remove extra (double etc.) spaces in _parse_message

### DIFF
--- a/slackminion/dispatcher.py
+++ b/slackminion/dispatcher.py
@@ -138,7 +138,7 @@ class MessageDispatcher(object):
     def _parse_message(self, message):
         if message:
             try:
-                args = unicodedata.normalize('NFKD', message.text).split(' ')
+                args = unicodedata.normalize('NFKD', message.text).split()
                 return args
             except AttributeError:
                 pass

--- a/slackminion/tests/test_dispatcher.py
+++ b/slackminion/tests/test_dispatcher.py
@@ -43,6 +43,11 @@ class TestDispatcher(unittest.TestCase):
         e = SlackEvent(event_type='message', **{'data': {'text': 'Hello world'}})
         assert self.dispatcher._parse_message(e) == ['Hello', 'world']
 
+    def test_parse_message_extra_space(self):
+        # Strip out extra spaces
+        e = SlackEvent(event_type='message', **{'data': {'text': 'Hello  world'}})
+        assert self.dispatcher._parse_message(e) == ['Hello', 'world']
+
     def test_parse_message_unicode(self):
         e = SlackEvent(event_type='message', **{'data': {'text': 'Hello\xa0world'}})
         assert self.dispatcher._parse_message(e) == ['Hello', 'world']


### PR DESCRIPTION
When parsing a message if the person adds an extra space, 'foo bar'
becomes ['foo', '', 'bar'] and can break plugins since the cmd matching
has to be exact (no extra spaces).