### PR TITLE
Use await/async thanks to slack_sdk

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         author_email='',
         description='A python bot framework for slack',
         package_data={'slackminion': ['templates/*']},
-        python_requires='>=3.6',
+        python_requires='>=3.7',
         install_requires=[
             'Flask>=1.1.1',
             'itsdangerous>=0.24',

--- a/slackminion/plugin/base.py
+++ b/slackminion/plugin/base.py
@@ -1,14 +1,20 @@
+from __future__ import annotations
+
 import logging
+import typing
 
 from six import string_types
 
 from slackminion.slack import SlackConversation, SlackUser
 
+if typing.TYPE_CHECKING:
+    from slackminion.bot import Bot
+
 
 class BasePlugin(object):
     notify_event_types = []
 
-    def __init__(self, bot, **kwargs):
+    def __init__(self, bot: Bot, **kwargs):
         self.log = logging.getLogger(type(self).__name__)
         self._bot = bot
         self._dont_save = False  # By default, we want to save a plugin's state during save_state()
@@ -46,7 +52,7 @@ class BasePlugin(object):
         """
         return True
 
-    def send_message(self, channel, text, thread=None, reply_broadcast=False, parse=None):
+    async def send_message(self, channel, text, thread=None, reply_broadcast=False, parse=None):
         """
         Used to send a message to the specified channel.
 
@@ -58,16 +64,16 @@ class BasePlugin(object):
         """
         self.log.debug('Sending message to channel {} of type {}'.format(channel, type(channel)))
         if isinstance(channel, SlackConversation):
-            self._bot.send_message(channel, text, thread, reply_broadcast, parse)
+            await self._bot.send_message(channel, text, thread, reply_broadcast, parse)
         elif isinstance(channel, string_types):
             if channel[0] == '@':
-                self._bot.send_im(channel[1:], text)
+                await self._bot.send_im(channel[1:], text)
             elif channel[0] == '#':
-                self._bot.send_message(channel[1:], text, thread, reply_broadcast, parse)
+                await self._bot.send_message(channel[1:], text, thread, reply_broadcast, parse)
             else:
-                self._bot.send_message(channel, text, thread, reply_broadcast, parse)
+                await self._bot.send_message(channel, text, thread, reply_broadcast, parse)
         else:
-            self._bot.send_message(channel, text, thread, reply_broadcast, parse)
+            await self._bot.send_message(channel, text, thread, reply_broadcast, parse)
 
     def start_periodic_task(self, duration, func, *args, **kwargs):
         """

--- a/slackminion/plugin/base.py
+++ b/slackminion/plugin/base.py
@@ -144,14 +144,14 @@ class BasePlugin(object):
         self._bot.user_manager.set(user)
         return user
 
-    def get_channel(self, channel):
+    async def get_channel(self, channel):
         """
         Utility function to query slack for a particular channel
 
         :param channel: The channel name or id of the channel to lookup
         :return: SlackChannel object or None
         """
-        return self._bot.get_channel(channel)
+        return await self._bot.get_channel(channel)
 
     def get_channel_by_name(self, channel_name):
         """
@@ -162,5 +162,5 @@ class BasePlugin(object):
         """
         return self._bot.get_channel_by_name(channel_name)
 
-    def at_user(self, *args, **kwargs):
-        return self._bot.at_user(*args, **kwargs)
+    async def at_user(self, *args, **kwargs):
+        return await self._bot.at_user(*args, **kwargs)

--- a/slackminion/plugin/manager.py
+++ b/slackminion/plugin/manager.py
@@ -1,11 +1,17 @@
+from __future__ import annotations
+
 import inspect
 import json
 import logging
+import typing
 from datetime import datetime
+
+if typing.TYPE_CHECKING:
+    from slackminion.bot import Bot
 
 
 class PluginManager(object):
-    def __init__(self, bot, test_mode=False):
+    def __init__(self, bot: Bot, test_mode=False):
         self.bot = bot
         self.config = bot.config
         self.dispatcher = bot.dispatcher

--- a/slackminion/plugins/core/__init__.py
+++ b/slackminion/plugins/core/__init__.py
@@ -1,1 +1,1 @@
-version = '1.2.0'
+version = '1.2.1'

--- a/slackminion/plugins/core/core.py
+++ b/slackminion/plugins/core/core.py
@@ -50,11 +50,11 @@ class Core(BasePlugin):
         return f"*{name}*: {helpstr}"
 
     @cmd(admin_only=True)
-    def save(self, msg, args):
+    async def save(self, msg, args):
         """Causes the bot to write its current state to backend."""
-        self.send_message(msg.channel, "Saving current state...")
+        await self.send_message(msg.channel, "Saving current state...")
         self._bot.plugin_manager.save_state()
-        self.send_message(msg.channel, "Done.")
+        await self.send_message(msg.channel, "Done.")
 
     @cmd(admin_only=True)
     def shutdown(self, msg, args):
@@ -73,7 +73,7 @@ class Core(BasePlugin):
         return '\n'.join(output)
 
     @cmd()
-    def sleep(self, msg, args):
+    async def sleep(self, msg, args):
         """Causes the bot to ignore all messages from the channel.
 
         Usage:
@@ -83,12 +83,12 @@ class Core(BasePlugin):
         if channel:
             self.log.info('Sleeping in %s', channel)
             self._bot.dispatcher.ignore(channel)
-            self.send_message(channel, 'Going to sleep, good night. Type !wake to wake me up')
+            await self.send_message(channel, 'Going to sleep, good night. Type !wake to wake me up')
         else:
             self.log.warning('!sleep called without a channel')
 
     @cmd(admin_only=True, while_ignored=True)
-    def wake(self, msg, args):
+    async def wake(self, msg, args):
         """Causes the bot to resume operation in the channel.
 
         Usage:
@@ -98,7 +98,7 @@ class Core(BasePlugin):
         if channel:
             self.log.info('Waking up in %s', channel.name)
             self._bot.dispatcher.unignore(channel)
-            self.send_message(channel, 'Hello, how may I be of service?')
+            await self.send_message(channel, 'Hello, how may I be of service?')
         else:
             self.log.warning('!wake called without a channel')
 

--- a/slackminion/plugins/test.py
+++ b/slackminion/plugins/test.py
@@ -21,14 +21,14 @@ class TestPlugin(BasePlugin):
         return "Nothing happens for %s" % msg.user
 
     @cmd()
-    def alert(self, msg, args):
+    async def alert(self, msg, args):
         """Alert everyone."""
-        self.send_message(self.config['channel'], '<!here>: something important is going to happen!')
+        await self.send_message(self.config['channel'], '<!here>: something important is going to happen!')
         return None
 
     @webhook('/echo', form_params='foo')
-    def web_echo(self, foo):
-        self.send_message(self.config['channel'], foo)
+    async def web_echo(self, foo):
+        await self.send_message(self.config['channel'], foo)
 
     @cmd()
     def shortsleep(self, msg, args):
@@ -54,11 +54,11 @@ class TestPlugin(BasePlugin):
         if len(args) > 0:
             channel.topic = ' '.join(args)
 
-    def _sleep_func(self):
-        self.send_message(self.config['channel'], 'Slept for a bit')
+    async def _sleep_func(self):
+        await self.send_message(self.config['channel'], 'Slept for a bit')
 
-    def _sleep_func2(self, channel, text):
-        self.send_message(channel, text)
+    async def _sleep_func2(self, channel, text):
+        await self.send_message(channel, text)
 
 
 class TestAclPlugin(BasePlugin):

--- a/slackminion/tests/test_bot.py
+++ b/slackminion/tests/test_bot.py
@@ -163,17 +163,17 @@ class TestBot(unittest.TestCase):
         self.object.user_manager.set.assert_called()
 
     # test _prepare_and_send_output without any command options set (reply in thread, etc.)
-    def test_prepare_and_send_output_no_cmd_options(self):
+    async def test_prepare_and_send_output_no_cmd_options(self):
         self.object.send_message = AsyncMock()
         self.object.send_im = mock.Mock()
         self.object.web_client = AsyncMock()
         #    async def _prepare_and_send_output(self, cmd, msg, cmd_options, output):
-        self.object._prepare_and_send_output(test_command, self.test_event, {}, test_output)
+        await self.object._prepare_and_send_output(test_command, self.test_event, {}, test_output)
         self.object.send_message.assert_called_with(self.test_event.channel, test_output, thread=test_thread_ts,
                                                     reply_broadcast=None, parse=None)
 
     # test _prepare_and_send_output with various options
-    def test_prepare_and_send_output_with_cmd_options(self):
+    async def test_prepare_and_send_output_with_cmd_options(self):
         self.object.send_message = mock.Mock()
         self.object.send_im = mock.Mock()
         self.object.web_client = AsyncMock()
@@ -182,7 +182,7 @@ class TestBot(unittest.TestCase):
             'reply_in_thread': True
         }
         self.assertEqual(self.test_event.thread_ts, test_thread_ts)
-        self.object._prepare_and_send_output(test_command, self.test_event, cmd_options, test_output)
+        await elf.object._prepare_and_send_output(test_command, self.test_event, cmd_options, test_output)
         self.object.send_message.assert_called_with(self.test_event.channel, test_output, thread=test_thread_ts,
                                                     reply_broadcast=None, parse=None)
 
@@ -191,7 +191,7 @@ class TestBot(unittest.TestCase):
             'reply_broadcast': True,
         }
 
-        self.object._prepare_and_send_output(test_command, self.test_event, cmd_options, test_output)
+        await self.object._prepare_and_send_output(test_command, self.test_event, cmd_options, test_output)
         self.object.send_message.assert_called_with(self.test_event.channel, test_output, thread=test_thread_ts,
                                                     reply_broadcast=True, parse=None)
 
@@ -199,14 +199,14 @@ class TestBot(unittest.TestCase):
             'parse': "full"
         }
 
-        self.object._prepare_and_send_output(test_command, self.test_event, cmd_options, test_output)
+        await self.object._prepare_and_send_output(test_command, self.test_event, cmd_options, test_output)
         self.object.send_message.assert_called_with(self.test_event.channel, test_output, thread=test_thread_ts,
                                                     reply_broadcast=None, parse="full")
 
         cmd_options = {
         }
 
-        self.object._prepare_and_send_output(test_command, self.test_event, cmd_options, test_output)
+        await self.object._prepare_and_send_output(test_command, self.test_event, cmd_options, test_output)
         self.object.send_message.assert_called_with(self.test_event.channel, test_output, thread=test_thread_ts,
                                                     reply_broadcast=None, parse=None)
 
@@ -234,11 +234,11 @@ class TestBot(unittest.TestCase):
             self.object.get_channel_by_name(test_channel_name)
         self.object.log.warning.assert_called_with('Bot.channels was called but self._bot_channels was empty!')
 
-    def test_at_user(self):
+    async def test_at_user(self):
         self.object.send_message = mock.Mock()
         test_message = "hi"
         expected_message = f'{test_user.at_user}: {test_message}'
-        self.object.at_user(test_user, test_channel_id, test_message)
+        await self.object.at_user(test_user, test_channel_id, test_message)
         self.object.send_message.assert_called_with(test_channel_id, expected_message)
 
     def test_unpack_payload(self):

--- a/slackminion/tests/test_core/test_core.py
+++ b/slackminion/tests/test_core/test_core.py
@@ -82,9 +82,9 @@ class TestCorePlugin(BasicPluginTest, unittest.TestCase):
         self.object._bot.dispatcher.register_plugin(self.object)
         assert self.object.help(self.test_event, ['help']) == format_docstring('Displays help for each command')
 
-    def test_save(self):
+    async def test_save(self):
         self.object.send_message = mock.Mock()
-        self.object.save(self.test_event, [])
+        await self.object.save(self.test_event, [])
 
         assert self.object.send_message.call_count == 2
 
@@ -104,26 +104,26 @@ class TestCorePlugin(BasicPluginTest, unittest.TestCase):
         output = self.object.whoami(self.test_event, None)
         assert output == f'Hello <@{test_user_id}|{test_user_name}>\nBot version: {version}-{test_commit}'
 
-    def test_sleep(self):
+    async def test_sleep(self):
         self.object._get_channel_from_msg_or_args = mock.Mock(return_value=TestChannel)
-        self.object.sleep(self.test_event, [])
+        await self.object.sleep(self.test_event, [])
         self.object._bot.dispatcher.ignore.assert_called_with(TestChannel)
 
-    def test_sleep_channel(self):
+    async def test_sleep_channel(self):
         self.object._get_channel_from_msg_or_args = mock.Mock(return_value=TestChannel)
-        self.object.sleep(self.test_event, [test_channel_name])
+        await self.object.sleep(self.test_event, [test_channel_name])
         self.object._bot.dispatcher.ignore.assert_called_with(TestChannel)
 
-    def test_wake(self):
+    async def test_wake(self):
         self.object._get_channel_from_msg_or_args = mock.Mock(return_value=TestChannel)
-        self.object.wake(self.test_event, [])
+        await self.object.wake(self.test_event, [])
         self.object._bot.dispatcher.unignore.assert_called_with(TestChannel)
 
     @mock.patch('slackminion.plugin.base.SlackConversation')
-    def test_wake_channel(self, mock_slackchannel):
+    async def test_wake_channel(self, mock_slackchannel):
         mock_slackchannel.return_value = test_conversation
         self.object.send_message = mock.Mock()
-        self.object.wake(test_conversation, [test_channel_name])
+        await self.object.wake(test_conversation, [test_channel_name])
         self.object.send_message.assert_called()
 
     def test_get_help_for_command(self):

--- a/slackminion/tests/test_plugin/test_base.py
+++ b/slackminion/tests/test_plugin/test_base.py
@@ -49,8 +49,8 @@ class TestBasePlugin(unittest.TestCase):
         self.plugin.stop_timer(dummy_func)
         self.plugin._bot.task_manager.stop_timer.assert_called_with(dummy_func.__name__)
 
-    def test_get_channel(self):
-        self.plugin.get_channel(test_channel_name)
+    async def test_get_channel(self):
+        await self.plugin.get_channel(test_channel_name)
         self.plugin._bot.get_channel.assert_called()
 
     @async_test
@@ -83,9 +83,9 @@ class TestBasePlugin(unittest.TestCase):
             await self.plugin.get_user(non_existent_user_id)
         self.plugin._bot.user_manager.get_by_username.assert_called_with(non_existent_user_id)
 
-    def test_send_message(self):
+    async def test_send_message(self):
         self.plugin._bot = mock.Mock()
-        self.plugin.send_message(test_channel, 'Yet another test string')
+        await self.plugin.send_message(test_channel, 'Yet another test string')
         self.plugin._bot.send_message.assert_called()
 
     def test_no_events_without_handler_method(self):


### PR DESCRIPTION
The slack_sdk async web client now returns coroutines instead of futures
so we now need more async/await keywords to ensure things still work.

The new slack_sdk web client calls are async while the old one returns a
Future (when run_async=True) via ensure_future.  And ensure_future makes sure
the co-routine is always scheduled
https://docs.python.org/3/library/asyncio-future.html

https://github.com/slackapi/python-slack-sdk/blob/main/slack_sdk/web/async_client.py
https://github.com/slackapi/python-slack-sdk/blob/555c891a4270df407f01e97a8ed322f58828815d/slack_sdk/web/legacy_client.py#L31
https://github.com/slackapi/python-slack-sdk/blob/v2/slack/web/client.py

In order to catch these cases use typing and pyright.

This now requires python 3.7 due to https://www.python.org/dev/peps/pep-0563/
https://docs.python.org/3/library/typing.html#constant