### PR TITLE
Bump version to 2.0.0

### DIFF
--- a/slackminion/plugins/core/__init__.py
+++ b/slackminion/plugins/core/__init__.py
@@ -1,1 +1,1 @@
-version = '1.2.1'
+version = '2.0.0'


### PR DESCRIPTION
Update API to be async for new slack_sdk. Major version bump because
there are backwards incompatible changes in the plugin API.

Releases aa0dfbe8446d5e2a79a358d2e2c9a5847be010a4