### PR TITLE
Drop six as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
             'MarkupSafe>=0.23',
             'PyYAML>=4.2b',
             'requests >=2.11, <3.0a0',
-            'six >=1.10, <2.0a0',
             'slack_sdk==3.13.0',
             'websocket-client >=0.35, <0.55.0',
             'Werkzeug>=0.10.4',

--- a/slackminion/dispatcher.py
+++ b/slackminion/dispatcher.py
@@ -50,7 +50,7 @@ class WebhookCommand(BaseCommand):
     def execute(self):
         args = {}
         form_params = self.form_params
-        if isinstance(self.form_params, string_types):
+        if isinstance(self.form_params, str):
             form_params = [self.form_params]
         if form_params is not None:
             for p in form_params:
@@ -158,7 +158,7 @@ class MessageDispatcher(object):
                 commands = [method.cmd_name]
                 if method.aliases is not None:
                     aliases = method.aliases
-                    if isinstance(method.aliases, string_types):
+                    if isinstance(method.aliases, str):
                         aliases = [method.aliases]
                     for alias in aliases:
                         commands.append(alias)

--- a/slackminion/plugin/base.py
+++ b/slackminion/plugin/base.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 import typing
 
-from six import string_types
-
 from slackminion.slack import SlackConversation, SlackUser
 
 if typing.TYPE_CHECKING:
@@ -65,7 +63,7 @@ class BasePlugin(object):
         self.log.debug('Sending message to channel {} of type {}'.format(channel, type(channel)))
         if isinstance(channel, SlackConversation):
             await self._bot.send_message(channel, text, thread, reply_broadcast, parse)
-        elif isinstance(channel, string_types):
+        elif isinstance(channel, str):
             if channel[0] == '@':
                 await self._bot.send_im(channel[1:], text)
             elif channel[0] == '#':


### PR DESCRIPTION
Since we only support python 3 no need for six anymore.

string_types == str under python 3 in six https://github.com/benjaminp/six/blob/45f1a230f9cc8e48372e19627b91ac06a2013292/six.py#L41.