### PR TITLE
Fix tests for async

### DIFF
--- a/slackminion/plugins/core/core.py
+++ b/slackminion/plugins/core/core.py
@@ -79,7 +79,7 @@ class Core(BasePlugin):
         Usage:
         !sleep [channel name] - ignore the specified channel (or current if none specified)
         """
-        channel = self._get_channel_from_msg_or_args(msg, args)
+        channel = await self._get_channel_from_msg_or_args(msg, args)
         if channel:
             self.log.info('Sleeping in %s', channel)
             self._bot.dispatcher.ignore(channel)
@@ -94,7 +94,7 @@ class Core(BasePlugin):
         Usage:
         !wake [channel name] - unignore the specified channel (or current if none specified)
         """
-        channel = self._get_channel_from_msg_or_args(msg, args)
+        channel = await self._get_channel_from_msg_or_args(msg, args)
         if channel:
             self.log.info('Waking up in %s', channel.name)
             self._bot.dispatcher.unignore(channel)
@@ -133,11 +133,11 @@ class Core(BasePlugin):
         }
         return render_template('status.html', **context)
 
-    def _get_channel_from_msg_or_args(self, msg, args):
+    async def _get_channel_from_msg_or_args(self, msg, args):
         channel = None
         if len(args) == 0:
             if isinstance(msg.channel, SlackConversation):
                 channel = msg.channel
         else:
-            channel = self.get_channel(args[0])
+            channel = await self.get_channel(args[0])
         return channel

--- a/slackminion/tests/fixtures/variables.py
+++ b/slackminion/tests/fixtures/variables.py
@@ -4,8 +4,8 @@ from unittest import mock
 from slackminion.slack import SlackConversation, SlackEvent, SlackUser
 
 
-def AsyncMock():
-    coro = mock.Mock(name="CoroutineResult")
+def AsyncMock(*args, **kwargs):
+    coro = mock.Mock(name="CoroutineResult", *args, **kwargs)
     corofunc = mock.Mock(name="CoroutineFunction", side_effect=asyncio.coroutine(coro))
     corofunc.coro = coro
     return corofunc

--- a/slackminion/tests/test_bot.py
+++ b/slackminion/tests/test_bot.py
@@ -163,6 +163,7 @@ class TestBot(unittest.TestCase):
         self.object.user_manager.set.assert_called()
 
     # test _prepare_and_send_output without any command options set (reply in thread, etc.)
+    @async_test
     async def test_prepare_and_send_output_no_cmd_options(self):
         self.object.send_message = AsyncMock()
         self.object.send_im = mock.Mock()
@@ -173,16 +174,16 @@ class TestBot(unittest.TestCase):
                                                     reply_broadcast=None, parse=None)
 
     # test _prepare_and_send_output with various options
+    @async_test
     async def test_prepare_and_send_output_with_cmd_options(self):
-        self.object.send_message = mock.Mock()
+        self.object.send_message = AsyncMock()
         self.object.send_im = mock.Mock()
         self.object.web_client = AsyncMock()
-        #    async def _prepare_and_send_output(self, cmd, msg, cmd_options, output):
         cmd_options = {
             'reply_in_thread': True
         }
         self.assertEqual(self.test_event.thread_ts, test_thread_ts)
-        await elf.object._prepare_and_send_output(test_command, self.test_event, cmd_options, test_output)
+        await self.object._prepare_and_send_output(test_command, self.test_event, cmd_options, test_output)
         self.object.send_message.assert_called_with(self.test_event.channel, test_output, thread=test_thread_ts,
                                                     reply_broadcast=None, parse=None)
 
@@ -234,8 +235,9 @@ class TestBot(unittest.TestCase):
             self.object.get_channel_by_name(test_channel_name)
         self.object.log.warning.assert_called_with('Bot.channels was called but self._bot_channels was empty!')
 
+    @async_test
     async def test_at_user(self):
-        self.object.send_message = mock.Mock()
+        self.object.send_message = AsyncMock()
         test_message = "hi"
         expected_message = f'{test_user.at_user}: {test_message}'
         await self.object.at_user(test_user, test_channel_id, test_message)

--- a/slackminion/tests/test_plugin/test_base.py
+++ b/slackminion/tests/test_plugin/test_base.py
@@ -21,7 +21,8 @@ slackminion.plugin.base.threading = mock.Mock()
 
 class TestBasePlugin(unittest.TestCase):
     def setUp(self):
-        dummy_bot = mock.Mock()
+        dummy_bot = AsyncMock()
+        dummy_bot.get_channel = AsyncMock()
         self.plugin = BasePlugin(dummy_bot)
 
     def tearDown(self):
@@ -49,6 +50,7 @@ class TestBasePlugin(unittest.TestCase):
         self.plugin.stop_timer(dummy_func)
         self.plugin._bot.task_manager.stop_timer.assert_called_with(dummy_func.__name__)
 
+    @async_test
     async def test_get_channel(self):
         await self.plugin.get_channel(test_channel_name)
         self.plugin._bot.get_channel.assert_called()
@@ -83,8 +85,10 @@ class TestBasePlugin(unittest.TestCase):
             await self.plugin.get_user(non_existent_user_id)
         self.plugin._bot.user_manager.get_by_username.assert_called_with(non_existent_user_id)
 
+    @async_test
     async def test_send_message(self):
-        self.plugin._bot = mock.Mock()
+        self.plugin._bot = AsyncMock()
+        self.plugin._bot.send_message = AsyncMock()
         await self.plugin.send_message(test_channel, 'Yet another test string')
         self.plugin._bot.send_message.assert_called()
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 pytest>=5.4.0
-pytest-asyncio
 pytest-cov==2.6.1
 codeclimate-test-reporter==0.1.2
 coverage==4.5.2


### PR DESCRIPTION
By default an async test will silently not run under pytest,
'pytest-asyncio' has a mode to fix that but it isn't working, so remove
it and manually make sure our async_test decorator is present and fix
the tests.

This helped uncover an issue with an missing await in _get_channel_from_msg_or_args