### PR TITLE
Don't throw an exception when a message has no text

### DIFF
--- a/slackminion/dispatcher.py
+++ b/slackminion/dispatcher.py
@@ -76,7 +76,7 @@ class MessageDispatcher(object):
         args = self._parse_message(event)
 
         # commands will always start with !
-        if not args[0].startswith('!'):
+        if len(args) == 0 or not args[0].startswith('!'):
             return None, None, None
 
         self.log.debug("Searching for command using chunks: %s", args)

--- a/slackminion/plugins/core/__init__.py
+++ b/slackminion/plugins/core/__init__.py
@@ -1,1 +1,1 @@
-version = '2.0.0'
+version = '2.0.1'

--- a/slackminion/tests/test_dispatcher.py
+++ b/slackminion/tests/test_dispatcher.py
@@ -156,10 +156,18 @@ class TestDispatcher(unittest.TestCase):
         assert cmd_opts.get('reply_broadcast') is True
         assert cmd_opts.get('reply_in_thread') is True
 
+
     @async_test
     async def test_push_not_command(self):
         payload = dict(self.test_payload)
         payload['data'].update({'text': 'Not a command'})
+        e = SlackEvent(event_type="message", **payload)
+        assert await self.dispatcher.push(e) == (None, None, None)
+
+    @async_test
+    async def test_push_no_text(self):
+        payload = dict(self.test_payload)
+        payload['data'].update({'text': ''})
         e = SlackEvent(event_type="message", **payload)
         assert await self.dispatcher.push(e) == (None, None, None)
 


### PR DESCRIPTION
By switching from `split(' ')` to `split()` the following behavior changed

```
>>> ''.split()
[]
>>> ''.split(' ')
['']
```

So now args could be an empty list. The impact of this issue is just a noisy
exception and nothing else, as if the text is empty it won't have a '!' in it
and cannot be a command
```
Traceback (most recent call last):
  File "slackminion-2.0.0-py3-none-any.whl/slackminion/bot.py", line 319, in _event_message
    cmd, output, cmd_options = await self.dispatcher.push(msg, self.dev_mode)
  File "slackminion-2.0.0-py3-none-any.whl/slackminion/dispatcher.py", line 79, in push
    if not args[0].startswith('!'):
IndexError: list index out of range
```

Bump version to 2.0.1 to fix this minor bug

Bug introduced in 09bc4a43b48549e2202a78bcd735e7d05e8d84db