### PR TITLE
Bump black and aiohttp versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "MarkupSafe>=0.23",
         "PyYAML>=4.2b",
         "requests >=2.11, <3.0a0",
-        "slack_sdk==3.13.0",
+        "slack_sdk==3.18.3",
         "websocket-client >=0.35, <0.55.0",
         "Werkzeug>=0.10.4",
         "aiohttp>=3.7.4.post0",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "slack_sdk==3.13.0",
         "websocket-client >=0.35, <0.55.0",
         "Werkzeug>=0.10.4",
-        "aiohttp==3.7.4.post0",
+        "aiohttp>=3.7.4.post0",
     ],
     entry_points={
         "console_scripts": [

--- a/slackminion/plugins/core/__init__.py
+++ b/slackminion/plugins/core/__init__.py
@@ -1,1 +1,1 @@
-version = "2.0.1"
+version = "2.0.2"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,6 @@ pytest-cov==2.6.1
 coverage==4.5.2
 mock==3.0.5
 isort==5.10.0
-black==22.1.0
+black==22.8.0
 future
 


### PR DESCRIPTION
These changes will update black and aiohttp versions. Tests ran with previous versions were erroring out with import issues.

```
[hfagundes] $ tox
GLOB sdist-make: /home/hfagundes/code/slackminion/setup.py
py3 inst-nodeps: /home/hfagundes/code/slackminion/.tox/.tmp/package/1/slackminion-2.0.2.zip
py3 installed: aiohttp==3.8.3,aiosignal==1.2.0,async-timeout==4.0.2,asynctest==0.13.0,attrs==22.1.0,black==22.8.0,certifi==2022.9.14,charset-normalizer==2.1.1,click==8.1.3,coverage==4.5.2,Flask==2.2.2,frozenlist==1.3.1,future==0.18.2,idna==3.4,importlib-metadata==4.12.0,iniconfig==1.1.1,isort==5.10.0,itsdangerous==2.1.2,Jinja2==3.1.2,MarkupSafe==2.1.1,mock==3.0.5,multidict==6.0.2,mypy-extensions==0.4.3,packaging==21.3,pathspec==0.10.1,platformdirs==2.5.2,pluggy==1.0.0,py==1.11.0,pyparsing==3.0.9,pytest==7.1.3,pytest-cov==2.6.1,PyYAML==6.0,requests==2.28.1,six==1.16.0,slack-sdk==3.13.0,slackminion @ file:///home/hfagundes/code/slackminion/.tox/.tmp/package/1/slackminion-2.0.2.zip,tomli==2.0.1,typed-ast==1.5.4,typing_extensions==4.3.0,urllib3==1.26.12,websocket-client==0.54.0,Werkzeug==2.2.2,yarl==1.8.1,zipp==3.8.1
py3 run-test-pre: PYTHONHASHSEED='2204379255'
py3 run-test: commands[0] | pytest
================================================================ test session starts ================================================================
platform linux -- Python 3.7.5, pytest-7.1.3, pluggy-1.0.0
cachedir: .tox/py3/.pytest_cache
rootdir: /home/hfagundes/code/slackminion, configfile: setup.cfg
plugins: cov-2.6.1
collected 115 items                                                                                                                                 

slackminion/tests/test_bot.py ...................                                                                                             [ 16%]
slackminion/tests/test_dispatcher.py .......................                                                                                  [ 36%]
slackminion/tests/test_util.py .                                                                                                              [ 37%]
slackminion/tests/test_core/test_acl.py ......................                                                                                [ 56%]
slackminion/tests/test_core/test_core.py ..............                                                                                       [ 68%]
slackminion/tests/test_plugin/test_base.py ...........                                                                                        [ 78%]
slackminion/tests/test_plugin/test_manager.py ..                                                                                              [ 80%]
slackminion/tests/test_slack/test_conversation.py .........                                                                                   [ 87%]
slackminion/tests/test_slack/test_event.py ........                                                                                           [ 94%]
slackminion/tests/test_slack/test_user.py ...                                                                                                 [ 97%]
slackminion/tests/test_slack/test_room/test_im.py ...                                                                                         [100%]

----------- coverage: platform linux, python 3.7.5-final-0 -----------
Name                                    Stmts   Miss  Cover   Missing
---------------------------------------------------------------------
slackminion/__init__.py                     0      0   100%
slackminion/__main__.py                    49     49     0%   1-81
slackminion/bot.py                        242     83    66%   54, 60, 64, 84, 93-114, 147-151, 162-176, 181, 188, 190, 213-220, 238-242, 257-261, 271-273, 306-307, 316-317, 329-338, 343, 364-367, 370, 390, 394-401
slackminion/dispatcher.py                 169     31    82%   51-59, 75, 86-87, 92, 116, 122, 124-133, 143, 151-153, 216, 221-223, 225-226
slackminion/exceptions.py                   0      0   100%
slackminion/plugin/__init__.py             22      0   100%
slackminion/plugin/base.py                 77     23    70%   9, 73, 75-82, 96-105, 126, 140, 143-147, 168-169, 187, 190
slackminion/plugin/manager.py             117     50    57%   10, 38, 54-58, 77-80, 93, 97-98, 101-105, 108-137, 141-142, 149-161
slackminion/plugins/__init__.py             2      0   100%
slackminion/plugins/core/__init__.py        1      0   100%
slackminion/plugins/core/acl.py           113      5    96%   16, 27, 139, 150, 162
slackminion/plugins/core/core.py           79     18    77%   28, 30, 34, 39, 74, 93, 108, 115-142, 147-148
slackminion/plugins/core/user.py           40     40     0%   1-66
slackminion/plugins/state/__init__.py      11      2    82%   15, 18
slackminion/plugins/state/file.py          14      4    71%   14-15, 18-19
slackminion/plugins/test.py                42     21    50%   14-15, 20, 25-28, 32, 37, 42, 46-49, 53-56, 59, 62, 69, 74, 79
slackminion/slack/__init__.py               3      0   100%
slackminion/slack/conversation.py          48      0   100%
slackminion/slack/event.py                 31      4    87%   29-31, 43
slackminion/slack/rtm_client.py             6      3    50%   10-12
slackminion/slack/user.py                  45      3    93%   27, 31, 68
slackminion/utils/__init__.py               0      0   100%
slackminion/utils/async_task.py           181    139    23%   16-25, 28-30, 35-36, 39, 44-51, 54-56, 59-63, 66-68, 82-84, 87-91, 94-103, 106-128, 131, 134-164, 169-181, 184-194, 197-201, 204-210, 213-214, 217-224, 229-233
slackminion/utils/util.py                  66     41    38%   19, 29-36, 40-95, 140
slackminion/webserver.py                   39     20    49%   25-48, 51-56
---------------------------------------------------------------------
TOTAL                                    1397    536    62%


================================================================ 115 passed in 1.84s ================================================================
isort inst-nodeps: /home/hfagundes/code/slackminion/.tox/.tmp/package/1/slackminion-2.0.2.zip
isort installed: aiohttp==3.8.3,aiosignal==1.2.0,async-timeout==4.0.2,asynctest==0.13.0,attrs==22.1.0,black==22.8.0,certifi==2022.9.14,charset-normalizer==2.1.1,click==8.1.3,coverage==4.5.2,Flask==2.2.2,frozenlist==1.3.1,future==0.18.2,idna==3.4,importlib-metadata==4.12.0,iniconfig==1.1.1,isort==5.10.0,itsdangerous==2.1.2,Jinja2==3.1.2,MarkupSafe==2.1.1,mock==3.0.5,multidict==6.0.2,mypy-extensions==0.4.3,packaging==21.3,pathspec==0.10.1,platformdirs==2.5.2,pluggy==1.0.0,py==1.11.0,pyparsing==3.0.9,pytest==7.1.3,pytest-cov==2.6.1,PyYAML==6.0,requests==2.28.1,six==1.16.0,slack-sdk==3.13.0,slackminion @ file:///home/hfagundes/code/slackminion/.tox/.tmp/package/1/slackminion-2.0.2.zip,tomli==2.0.1,typed-ast==1.5.4,typing_extensions==4.3.0,urllib3==1.26.12,websocket-client==0.54.0,Werkzeug==2.2.2,yarl==1.8.1,zipp==3.8.1
isort run-test-pre: PYTHONHASHSEED='2204379255'
isort run-test: commands[0] | isort --check .
Skipped 2 files
black inst-nodeps: /home/hfagundes/code/slackminion/.tox/.tmp/package/1/slackminion-2.0.2.zip
black installed: aiohttp==3.8.3,aiosignal==1.2.0,async-timeout==4.0.2,asynctest==0.13.0,attrs==22.1.0,black==22.8.0,certifi==2022.9.14,charset-normalizer==2.1.1,click==8.1.3,coverage==4.5.2,Flask==2.2.2,frozenlist==1.3.1,future==0.18.2,idna==3.4,importlib-metadata==4.12.0,iniconfig==1.1.1,isort==5.10.0,itsdangerous==2.1.2,Jinja2==3.1.2,MarkupSafe==2.1.1,mock==3.0.5,multidict==6.0.2,mypy-extensions==0.4.3,packaging==21.3,pathspec==0.10.1,platformdirs==2.5.2,pluggy==1.0.0,py==1.11.0,pyparsing==3.0.9,pytest==7.1.3,pytest-cov==2.6.1,PyYAML==6.0,requests==2.28.1,six==1.16.0,slack-sdk==3.13.0,slackminion @ file:///home/hfagundes/code/slackminion/.tox/.tmp/package/1/slackminion-2.0.2.zip,tomli==2.0.1,typed-ast==1.5.4,typing_extensions==4.3.0,urllib3==1.26.12,websocket-client==0.54.0,Werkzeug==2.2.2,yarl==1.8.1,zipp==3.8.1
black run-test-pre: PYTHONHASHSEED='2204379255'
black run-test: commands[0] | black --check .
All done! ✨ 🍰 ✨
50 files would be left unchanged.
______________________________________________________________________ summary ______________________________________________________________________
  py3: commands succeeded
  isort: commands succeeded
  black: commands succeeded
  congratulations :)
```